### PR TITLE
fix: Prevent race condition upon unsubscribe after IPFS has stopped

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -90,7 +90,9 @@ class PubSubRoom extends EventEmitter {
     })
 
     this.once('stop', () => {
-      this._ipfs.pubsub.unsubscribe(this._topic, listener)
+      if (this._ipfs.state.stopped()) {
+        this._ipfs.pubsub.unsubscribe(this._topic, listener)
+      }
     })
 
     this._ipfs._libp2pNode.handle(PROTOCOL, this._handleDirectConnection.bind(this))
@@ -140,7 +142,7 @@ class PubSubRoom extends EventEmitter {
 
           // Until we figure out a good way to bring in the js-libp2p-floosub's randomSeqno
           // generator, let's use -1 as the sequence number for all private messages
-          const seqno = Buffer.from(-1)
+          const seqno = Buffer.from('-1')
 
           this.emit('message', {
             from: peerId,


### PR DESCRIPTION
This PR will prevent a race condition to mess with pubsub upon unsubscribe after IPFS has stopped. 

Currently, if the IPFS state is not checked and we unsubscribe, an error is thrown: "Floodsub not started". I believe this is due to the 'stop' message being emitted after IPFS has been stopped in a way that Floodsub already thinks we've stopped.

This PR also fixes a bug in the previous PR: fix buffer creation for sequence number in direct messages. I accidentally left the Buffer creation argument as an integer whereas it should be a string, eg. `Buffer.from('-1')`.

The fix here is a workaround for the unsubscribe as it doesn't solve the underlaying issue with the order of events being sent (race), so feel free to reject the fix if you want fix it upstream.