### PR TITLE
Connection: use correct method when dialling with protocol

### DIFF
--- a/src/connection.js
+++ b/src/connection.js
@@ -47,7 +47,7 @@ module.exports = class Connection extends EventEmitter {
         return // early
       }
 
-      this._ipfs._libp2pNode.dial(peerAddresses[0], PROTOCOL, (err, conn) => {
+      this._ipfs._libp2pNode.dialProtocol(peerAddresses[0], PROTOCOL, (err, conn) => {
         if (err) {
           this.emit('disconnect')
           return // early


### PR DESCRIPTION
Was getting a `callback is not a function` error, when I debugged `callback` got `ipfs-pubsub-room/v2` (which is the protocol).

https://github.com/libp2p/js-libp2p/blob/master/src/index.js#L246