### PR TITLE
fix: also support ipfs.libp2p

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,14 +30,14 @@
     "hyperdiff": "^2.0.5",
     "lodash.clonedeep": "^4.5.0",
     "pull-pushable": "^2.2.0",
-    "pull-stream": "^3.6.8"
+    "pull-stream": "^3.6.9"
   },
   "devDependencies": {
     "async": "^2.6.1",
-    "chai": "^4.1.2",
+    "chai": "^4.2.0",
     "dirty-chai": "^2.0.1",
-    "aegir": "^15.0.0",
-    "ipfs": "~0.32.0"
+    "aegir": "^18.0.3",
+    "ipfs": "~0.34.4"
   },
   "browser": {
     "./test/utils/create-repo-node.js": "./test/utils/create-repo-browser.js"

--- a/src/connection.js
+++ b/src/connection.js
@@ -7,6 +7,7 @@ const Pushable = require('pull-pushable')
 const PROTOCOL = require('./protocol')
 const encoding = require('./encoding')
 const getPeerId = require('./peer-id')
+const libp2p = require('./libp2p')
 
 module.exports = class Connection extends EventEmitter {
   constructor (id, ipfs, room) {
@@ -48,7 +49,7 @@ module.exports = class Connection extends EventEmitter {
         return // early
       }
 
-      this._ipfs._libp2pNode.dialProtocol(peerAddresses[0], PROTOCOL, (err, conn) => {
+      libp2p(this._ipfs).dialProtocol(peerAddresses[0], PROTOCOL, (err, conn) => {
         if (err) {
           this.emit('disconnect')
           return // early

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,7 @@ const PROTOCOL = require('./protocol')
 const Connection = require('./connection')
 const encoding = require('./encoding')
 const directConnection = require('./direct-connection-handler')
+const libp2p = require('./libp2p')
 
 const DEFAULT_OPTIONS = {
   pollInterval: 1000
@@ -130,7 +131,7 @@ class PubSubRoom extends EventEmitter {
       })
     })
 
-    this._ipfs._libp2pNode.handle(PROTOCOL, directConnection.handler)
+    libp2p(this._ipfs).handle(PROTOCOL, directConnection.handler)
 
     directConnection.emitter.on(this._topic, this._handleDirectMessage)
   }

--- a/src/libp2p.js
+++ b/src/libp2p.js
@@ -1,0 +1,5 @@
+'use strict'
+
+module.exports = (ipfs) => {
+  return ipfs._libp2pNode || ipfs.libp2p
+}


### PR DESCRIPTION
Besides `ipfs._lip2pNode`, also support the new `ipfs.libp2p`.