### PR TITLE
fix for libp2p 0.31

### DIFF
--- a/.aegir.js
+++ b/.aegir.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const Libp2p = require('libp2p')
-const PeerInfo = require('peer-info')
 const { config } = require('./test/utils/create-libp2p')
 
 let relay
@@ -9,14 +8,13 @@ let relay
 module.exports = {
   hooks: {
     pre: async () => {
-      const peerInfo = await PeerInfo.create()
-      peerInfo.multiaddrs.add('/ip4/127.0.0.1/tcp/24642/ws')
-
-      const defaultConfig = await config()
+      const defaultConfig = await config(true)
 
       relay = new Libp2p({
         ...defaultConfig,
-        peerInfo,
+        addresses: {
+          listen: ['/ip4/127.0.0.1/tcp/24642/ws'],
+        },
         config: {
           ...defaultConfig.config,
           relay: {

--- a/package.json
+++ b/package.json
@@ -36,19 +36,21 @@
   "dependencies": {
     "hyperdiff": "^2.0.5",
     "it-pipe": "^1.1.0",
-    "lodash.clonedeep": "^4.5.0"
+    "lodash.clonedeep": "^4.5.0",
+    "uint8arrays": "^2.1.5"
   },
   "devDependencies": {
     "aegir": "^20.5.1",
     "chai": "^4.2.0",
     "delay": "^4.3.0",
     "dirty-chai": "^2.0.1",
-    "libp2p": "0.27.0-rc.0",
-    "libp2p-gossipsub": "0.2.1",
-    "libp2p-mplex": "^0.9.3",
-    "libp2p-secio": "^0.12.2",
-    "libp2p-websockets": "^0.13.2",
-    "peer-info": "^0.17.1",
+    "libp2p": "0.31.5",
+    "libp2p-gossipsub": "0.9.0",
+    "libp2p-mplex": "^0.10.3",
+    "libp2p-secio": "^0.13.1",
+    "libp2p-websockets": "^0.15.7",
+    "multiaddr": "^9.0.1",
+    "peer-id": "^0.14.8",
     "rimraf": "^3.0.0"
   },
   "contributors": [

--- a/src/connection.js
+++ b/src/connection.js
@@ -2,6 +2,7 @@
 
 const EventEmitter = require('events')
 const pipe = require('it-pipe')
+const PeerId = require('peer-id')
 
 const PROTOCOL = require('./protocol')
 const encoding = require('./encoding')
@@ -47,8 +48,8 @@ module.exports = class Connection extends EventEmitter {
       return // early
     }
 
-    const peerInfo = this._libp2p.peerStore.get(this._remoteId)
-    const { stream } = await this._libp2p.dialProtocol(peerInfo, PROTOCOL)
+    const remotePeerId = await PeerId.createFromB58String(this._remoteId)
+    const { stream } = await this._libp2p.dialProtocol(remotePeerId, PROTOCOL)
     this._connection = new FiFoMessageQueue()
 
     pipe(this._connection, stream, async (source) => {

--- a/src/direct-connection-handler.js
+++ b/src/direct-connection-handler.js
@@ -2,8 +2,19 @@
 
 const EventEmitter = require('events')
 const pipe = require('it-pipe')
+const uint8ArrayToString = require('uint8arrays/to-string')
 
 const emitter = new EventEmitter()
+
+const hexStringToUint8Array = (str) => {
+  const size = str.length / 2
+  const buf = new Uint8Array(size)
+  for (let i = 0; i < size; i += 1) {
+    buf[i] = parseInt(str.slice(i * 2, i * 2 + 2), 16)
+  }
+  buf.toString = function () { return uint8ArrayToString(this) }
+  return buf
+}
 
 function handler ({ connection, stream }) {
   const peerId = connection.remotePeer.toB58String()
@@ -32,8 +43,8 @@ function handler ({ connection, stream }) {
           continue // early
         }
 
-        msg.data = Buffer.from(msg.data, 'hex')
-        msg.seqno = Buffer.from(msg.seqno, 'hex')
+        msg.data = hexStringToUint8Array(msg.data)
+        msg.seqno = hexStringToUint8Array(msg.seqno)
 
         topicIDs.forEach((topic) => {
           emitter.emit(topic, msg)

--- a/src/encoding.js
+++ b/src/encoding.js
@@ -1,9 +1,17 @@
 'use strict'
 
+const uint8ArrayFromString = require('uint8arrays/from-string')
+
 module.exports = (_message) => {
-  let message = _message
-  if (!Buffer.isBuffer(message)) {
-    message = Buffer.from(message)
+  let message
+  if (_message instanceof Uint8Array) {
+    message = _message
+  } else if (_message instanceof ArrayBuffer) {
+    message = new Uint8Array(_message)
+  } else if (typeof _message === 'string') {
+    message = uint8ArrayFromString(_message)
+  } else {
+    throw new Error('unable to encode message')
   }
   return message
 }

--- a/test/concurrent-rooms.spec.js
+++ b/test/concurrent-rooms.spec.js
@@ -23,12 +23,12 @@ describe('concurrent rooms', function () {
 
   before(async () => {
     node1 = await createLibp2p()
-    id1 = node1.peerInfo.id.toB58String()
+    id1 = node1.peerId.toB58String()
   })
 
   before(async () => {
     node2 = await createLibp2p(node1)
-    id2 = node2.peerInfo.id.toB58String()
+    id2 = node2.peerId.toB58String()
   })
 
   after(() => {

--- a/test/room.spec.js
+++ b/test/room.spec.js
@@ -18,12 +18,12 @@ describe('room', function () {
 
   before(async () => {
     node1 = await createLibp2p()
-    id1 = node1.peerInfo.id.toB58String()
+    id1 = node1.peerId.toB58String()
   })
 
   before(async () => {
     node2 = await createLibp2p(node1)
-    id2 = node2.peerInfo.id.toB58String()
+    id2 = node2.peerId.toB58String()
   })
 
   const rooms = []

--- a/test/utils/create-libp2p.js
+++ b/test/utils/create-libp2p.js
@@ -5,13 +5,19 @@ const WS = require('libp2p-websockets')
 const Multiplex = require('libp2p-mplex')
 const SECIO = require('libp2p-secio')
 const GossipSub = require('libp2p-gossipsub')
-const PeerInfo = require('peer-info')
+const PeerId = require('peer-id')
+const { multiaddr } = require('multiaddr')
 
 const RELAY_MULTIADDR = '/ip4/127.0.0.1/tcp/24642/ws'
+const RELAY_PEER_ID_JSON = {
+  id: 'QmQLNqWfXdTAEPsCWtiaVhDCCFfsYian7YLryRdQn3fgL4',
+  privKey: 'CAASqAkwggSkAgEAAoIBAQDVCnVIHt/xx3LlS0bHUlS6A1oxuqfwrzCSNrr0T68RM1i/2zc1Pl6dMLdhpzIrMHrt6J4nMA2nzC71vHNvymQeLWvKmAWTEcKbGR8lQGHibBMP/1vwOwFlKxy3JzaqDS8hP6qTnMgGpMJosiroitTNHAJg2PCQM0zX+Q8ehsiwhoJ5IaIoCzutyo7S5X7uubOjUMj+tAVuX34/lz8ynQfnfFeS6GuCddsljg/RZ3c+wS+EPwsNd0VJjm3L5M9b+Ofh8IW5FI/MMmHg2+dpHJnZv9QCtclvCZJj0xUKpxtluM5NHd64h+fBQsmpB75b2eUkB3RUNLy/ngC50NbAIRN1AgMBAAECggEBAJW/HiUtnpgia76EpSGh23BMvu9JlpZ1bhy4X70u7Y2XnABvpGTGjFbNUXlQvtDg6OelpNVCz7ZsrW2Jo1Km3qzfnG7xYKm5yCKhC+VxVdyDvvp1sjgwIZDtNuf+pkvtrH0gdVQA1hDlasmQwtxmCaKK15kfpCiYBqGgrWH1t8dr3H4Vk2BUkQeryQ1kmRZ3fUJw+VNiB7yhmw+tx5ytFB3OMNxvUPylHM07s8VjpZ7B8Xde3jOlJYJFBQ7k1rkfuULtc5XD+7DrsF0DutN7X3N1TZf2iBYGwttN6CfHC8yRxwIgWzli53ldUV1YhtBB8MgCWUMbttfmoe9Fo9yMNoECgYEA8PTwPXwljlx4eAzr8FZD8HifXXTYcuVhpepFx5jlMwJ1sTYr2nIfaEf136iweYIv6A/5+7/S8yFmdlaf3Ito9m/6qXGUD8I5h90YSUyeBJy1IEPg1dqM+nIufMh9Oo++VPs/xnUEbcpCVfMUK4Gr1l/iLes70nEFjcI9VZVvZdECgYEA4ldbUfGvc/cwUbIgVTHFIeg0czd1XlOic8ur9x1MdhVIi0AjVZzV223E0X2qg90uCV9Ztn7kz9e9Z5e2tRidcfJ+1/t7M5l/NSCbD85H3HSZVBklwOft968KauboLtE2cFyve/ZM7s9aG8fEwi88IktsxHk9Dvb4x35JQOQBaGUCgYEAhPsZL0W50GS2U8MF36EsY6Wehkx7PIXdq1ys4ChArjM4UvILp8Z+EOZOCv6lTpoL6G4Qz+ChAm+3ha3vEh+acQ+B7kvxo/TUHWhnA+UV/IOj7senaT7xuTKU92cKvewg5fO30cY5CIKss5Sw2AX7mRdX03HUlSKtJvxBL1+GmFECgYADYZCwqa6YSeID5mhLPYIXXpOiAPsU3KT5m9pGx75DqU+7HMsqVTxwmbQt+PWaIKy2YSFC86RRYoSmzoJhNCvt7tRsP4p4m9tlnMYUN12lcmxz8Cg7OHu6jnfWXvqq8F8i0I+ih2xgyOIsthA/YltAm+XVDYaW+aN/v2gyuvU2bQKBgH2wWDWTQEJ4eX9ZwDmzCWKZlS6Hgb7bxxxE6g9asE6t0GwjcaMsLL4H7NajuEmxYWmDOVcGN04n/9NbTwZ+WQeTCLUGVLZxRo7bfyNVrbUoY21X7FrMptwX2GXg4U/JmkOYXN4xhgHXbzZVZwCiIjuXi9h/lJ4s+djses5P5T32',
+  pubKey: 'CAASpgIwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDVCnVIHt/xx3LlS0bHUlS6A1oxuqfwrzCSNrr0T68RM1i/2zc1Pl6dMLdhpzIrMHrt6J4nMA2nzC71vHNvymQeLWvKmAWTEcKbGR8lQGHibBMP/1vwOwFlKxy3JzaqDS8hP6qTnMgGpMJosiroitTNHAJg2PCQM0zX+Q8ehsiwhoJ5IaIoCzutyo7S5X7uubOjUMj+tAVuX34/lz8ynQfnfFeS6GuCddsljg/RZ3c+wS+EPwsNd0VJjm3L5M9b+Ofh8IW5FI/MMmHg2+dpHJnZv9QCtclvCZJj0xUKpxtluM5NHd64h+fBQsmpB75b2eUkB3RUNLy/ngC50NbAIRN1AgMBAAE='
+}
 
-const config = async () => {
+const config = async (isRelay) => {
   return {
-    peerInfo: await PeerInfo.create(),
+    peerId: isRelay ? await PeerId.createFromJSON(RELAY_PEER_ID_JSON) : await PeerId.create(),
     dialer: {
       maxParallelDials: 150, // 150 total parallel multiaddr dials
       maxDialsPerPeer: 4, // Allow 4 multiaddrs to be dialed per peer in parallel
@@ -50,13 +56,15 @@ module.exports = async (otherNode) => {
   await node.start()
 
   // connect to relay peer
-  await node.dial(RELAY_MULTIADDR)
+  const relayPeerId = await PeerId.createFromJSON(RELAY_PEER_ID_JSON)
+  node.peerStore.addressBook.add(relayPeerId, [multiaddr(RELAY_MULTIADDR)])
+  await node.dial(relayPeerId)
 
   // both nodes created, get them to dial each other via the relay
   if (otherNode) {
     const relayId = node.connections.keys().next().value
-    const otherNodeId = otherNode.peerInfo.id.toB58String()
-    const nodeId = node.peerInfo.id.toB58String()
+    const otherNodeId = otherNode.peerId.toB58String()
+    const nodeId = node.peerId.toB58String()
 
     await node.dial(`${RELAY_MULTIADDR}/p2p/${relayId}/p2p-circuit/p2p/${otherNodeId}`)
     await otherNode.dial(`${RELAY_MULTIADDR}/p2p/${relayId}/p2p-circuit/p2p/${nodeId}`)


### PR DESCRIPTION
https://github.com/libp2p/js-libp2p/tree/master/doc/migrations

`npm run test:node` passes but `npm run test:browser` doesn't. Any hint?