### PR TITLE
fix: libp2p undefined error

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -34,7 +34,7 @@ export default class PubSubRoom extends EventEmitter {
       this._options.pollInterval
     )
 
-    directConnection.handle(libp2p)
+    directConnection.handle(this._libp2p)
     directConnection.emitter.on(this._topic, this._handleDirectMessage)
 
     this._libp2p.pubsub.subscribe(this._topic)


### PR DESCRIPTION
Found `TypeError: libp2p.handle is not a function` error.
Seems like a regression in #84.

